### PR TITLE
Fix/handle datocms blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-address-autocomplete",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/elevationchurch/datocms-plugin-adress-autocomplete",
   "description": "A React-based implementation of Google's Address Autocomplete API, for DatoCMS.",
   "author": {

--- a/src/entrypoints/AddressInput/index.tsx
+++ b/src/entrypoints/AddressInput/index.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   FunctionComponent,
   createRef,
   useEffect,
@@ -19,6 +19,7 @@ import { ValidParameters } from '../ConfigScreen';
 import styles from './AddressInput.module.css';
 import saveFieldValue from '../../lib/saveFieldValue';
 import fillInAddress from '../../lib/fillInAddress';
+import getInitialValue from '../../lib/getInitialValue';
 
 interface AddressInputProps {
   ctx: RenderFieldExtensionCtx;
@@ -41,10 +42,18 @@ const initialAddress = {
   },
 };
 
+const resolvePath = (
+  obj: { [key: string]: any },
+  path: string,
+  defaultValue = {},
+) => path.split('.').reduce((o, p) => (o ? o[p] : defaultValue), obj);
+
 const AddressInput: FunctionComponent<AddressInputProps> = ({ ctx }) => {
   // Initial value doesn't change, which is why we put it in a ref
   const initialValue = useRef(
-    JSON.parse(ctx.formValues[ctx.fieldPath] as string),
+    typeof ctx.formValues[ctx.fieldPath] === 'string'
+      ? JSON.parse(ctx.formValues[ctx.fieldPath] as string)
+      : JSON.parse(getInitialValue(ctx.fieldPath, ctx.formValues, '.')),
   );
 
   // URL to Google's library

--- a/src/lib/getInitialValue.ts
+++ b/src/lib/getInitialValue.ts
@@ -1,0 +1,10 @@
+export default function getInitialValue(
+  path: string,
+  obj: any,
+  separator = '.',
+) {
+  const properties = Array.isArray(path)
+    ? path
+    : (path.split(separator) as any);
+  return properties.reduce((prev: any, curr: any) => prev?.[curr], obj);
+}


### PR DESCRIPTION
When extracting the initial value, we can now do so from a nested field path. So, the plugin will no longer break when the field is used inside of a block.