### PR TITLE
feat: add utc_offset_minutes to object just for fun

### DIFF
--- a/src/entrypoints/AddressInput/index.tsx
+++ b/src/entrypoints/AddressInput/index.tsx
@@ -40,6 +40,7 @@ const initialAddress = {
     lat: '',
     lng: '',
   },
+  utc_offset_minutes: undefined,
 };
 
 const AddressInput: FunctionComponent<AddressInputProps> = ({ ctx }) => {
@@ -75,6 +76,7 @@ const AddressInput: FunctionComponent<AddressInputProps> = ({ ctx }) => {
             'geometry',
             'name',
             'formatted_address',
+            'utc_offset_minutes',
           ],
         },
       );
@@ -200,6 +202,14 @@ const AddressInput: FunctionComponent<AddressInputProps> = ({ ctx }) => {
             <TextInput
               disabled
               value={address.coordinates ? address.coordinates.lng : ''}
+            />
+          </FieldWrapper>
+          <FieldWrapper id='utc-offset-minutes' label='UTC Offset Minutes'>
+            <TextInput
+              disabled
+              value={
+                address.utc_offset_minutes ? address.utc_offset_minutes : ''
+              }
             />
           </FieldWrapper>
         </FieldGroup>

--- a/src/lib/fillInAddress.ts
+++ b/src/lib/fillInAddress.ts
@@ -29,6 +29,8 @@ const fillInAddress = (
   addressComponents.coordinates.lat = place.geometry?.location?.lat();
   addressComponents.coordinates.lng = place.geometry?.location?.lng();
 
+  addressComponents.utc_offset_minutes = place.utc_offset_minutes;
+
   saveFieldValue(ctx, addressComponents);
 
   setAddress(addressComponents as any);


### PR DESCRIPTION
Address object now contains property [utc_offset_minutes](https://developers.google.com/maps/documentation/javascript/places#place_details_results)

```utc_offset_minutes contains the number of minutes this place’s current timezone is offset from UTC. For example, for places in Sydney, Australia during daylight saving time this would be 660 (+11 hours from UTC), and for places in California outside of daylight saving time this would be -480 (-8 hours from UTC).```